### PR TITLE
feat: refine base styling and card UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,32 +1,36 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background-start: #0B0B0C;
+  --background-end: #0E0E11;
+  --foreground: rgba(255, 255, 255, 0.92);
+  --foreground-secondary: rgba(255, 255, 255, 0.75);
+  --border: rgba(255, 255, 255, 0.10);
+  --accent: 245 100% 67%;
 }
 
 @theme inline {
-  --color-background: var(--background);
+  --color-background: var(--background-start);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  background: var(--background);
+  background: linear-gradient(180deg, var(--background-start), var(--background-end));
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
 }
 
-:root {
-  --accent: 245 100% 67%; /* tweak later */
+.text-secondary {
+  color: var(--foreground-secondary);
 }
-a { text-underline-offset: 3px; }
-a:hover { text-decoration-thickness: 2px; }
+
+a {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+a:hover {
+  color: hsl(var(--accent));
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -34,7 +34,7 @@ export default function Navbar() {
               <li key={l.href}>
                 <Link
                   href={l.href}
-                  className={`transition-opacity hover:opacity-100 ${active ? 'opacity-100 underline' : 'opacity-80'}`}
+                  className={`transition-opacity hover:opacity-100 no-underline ${active ? 'opacity-100 underline underline-offset-4' : 'opacity-80'}`}
                   aria-current={active ? 'page' : undefined}
                 >
                   {l.label}
@@ -62,14 +62,14 @@ export default function Navbar() {
       {/* Mobile sheet */}
       {open && (
         <div id="mobile-menu" className="md:hidden border-t border-white/10">
-          <ul className="max-w-6xl mx-auto px-4 py-3 flex flex-col gap-3">
+          <ul className="max-w-6xl mx-auto px-4 py-3 flex flex-col gap-3 text-sm">
             {links.map((l) => {
               const active = pathname === l.href;
               return (
                 <li key={l.href}>
                   <Link
                     href={l.href}
-                    className={`block py-1 ${active ? 'underline' : 'opacity-90'}`}
+                    className={`block py-2 ${active ? 'underline underline-offset-4' : 'opacity-90 no-underline'}`}
                     onClick={() => setOpen(false)}
                     aria-current={active ? 'page' : undefined}
                   >

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -32,3 +32,17 @@ export function ButtonLink({ href, children, variant = 'primary', className = ''
     </Link>
   );
 }
+
+export type CardProps = React.HTMLAttributes<HTMLDivElement> & {
+  as?: React.ElementType;
+  className?: string;
+};
+
+export function Card({ as: Component = 'div', className = '', ...props }: CardProps) {
+  return (
+    <Component
+      className={`rounded-2xl border border-white/10 p-5 hover:bg-white/5 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white ${className}`}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- adopt near-black gradient theme, accent color variable, and global link styling
- add reusable Card component with hover and focus states
- update navigation links for offset underline and mobile spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689f94a67590832cba217c0f90bb607f